### PR TITLE
chore(deps): update GitHub Actions to latest versions

### DIFF
--- a/.github/actions/build-solution/action.yml
+++ b/.github/actions/build-solution/action.yml
@@ -72,7 +72,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 

--- a/.github/actions/setup-pac-cli/action.yml
+++ b/.github/actions/setup-pac-cli/action.yml
@@ -27,7 +27,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 

--- a/.github/workflows/_deploy-solution.yml
+++ b/.github/workflows/_deploy-solution.yml
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/ci-export.yml
+++ b/.github/workflows/ci-export.yml
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: develop
           fetch-depth: 0  # Full history for tagging
@@ -248,7 +248,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.has_changes.outputs.result == 'true' && github.event.inputs.create_pr == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: sync solution from Dev (v${{ steps.version.outputs.new_version }})'

--- a/.github/workflows/ci-plugin-deploy.yml
+++ b/.github/workflows/ci-plugin-deploy.yml
@@ -72,10 +72,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET Framework compatibility
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.x'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect .NET solution
         id: detect
@@ -68,7 +68,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: steps.detect.outputs.has-solution == 'true'
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: csharp
           # Use security-and-quality for comprehensive analysis
@@ -76,7 +76,7 @@ jobs:
 
       - name: Setup .NET SDK
         if: steps.detect.outputs.has-solution == 'true'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.x'
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Perform CodeQL Analysis
         if: steps.detect.outputs.has-solution == 'true'
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:csharp"
 

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
@@ -122,7 +122,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect .NET solution
         id: detect
@@ -166,7 +166,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PAC CLI
         uses: ./.github/actions/setup-pac-cli
@@ -174,7 +174,7 @@ jobs:
       # Build and copy plugin components if build succeeded
       - name: Setup .NET SDK
         if: needs.build-code.outputs.build-succeeded == 'true'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.x'
 


### PR DESCRIPTION
## Summary

Batched update of GitHub Actions dependencies to their latest major versions:

| Action | Previous | New | Notes |
|--------|----------|-----|-------|
| `actions/checkout` | v4 | v6 | Node.js 24, new credential storage |
| `actions/setup-dotnet` | v4 | v5 | Node.js 24 |
| `github/codeql-action` | v3 | v4 | Updated CodeQL bundle |
| `peter-evans/create-pull-request` | v5 | v8 | Node.js 24, checkout v6 compat |

## Requirements

- GitHub-hosted runners: Should work automatically
- Self-hosted runners: Require runner v2.329.0+

## Test plan

- [ ] Verify PR validation workflow runs successfully
- [ ] Verify CodeQL analysis completes
- [ ] Verify ci-export workflow functions correctly

Closes Dependabot PRs #6, #7, #8, #9