### PR TITLE
fix: standardize composite action output names

### DIFF
--- a/.github/workflows/_deploy-solution.yml
+++ b/.github/workflows/_deploy-solution.yml
@@ -96,7 +96,7 @@ on:
         value: ${{ jobs.deploy.outputs.version }}
       build-succeeded:
         description: 'Whether plugin build succeeded (if enabled)'
-        value: ${{ jobs.deploy.outputs.build_succeeded }}
+        value: ${{ jobs.deploy.outputs.build-succeeded }}
 
 jobs:
   deploy:
@@ -107,7 +107,7 @@ jobs:
       deployed: ${{ steps.import.outputs.imported }}
       skipped: ${{ steps.import.outputs.skipped }}
       version: ${{ steps.import.outputs.import-version }}
-      build_succeeded: ${{ steps.build.outputs.build-succeeded }}
+      build-succeeded: ${{ steps.build.outputs.build-succeeded }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-export.yml
+++ b/.github/workflows/ci-export.yml
@@ -94,9 +94,9 @@ jobs:
       pull-requests: write
 
     outputs:
-      has_changes: ${{ steps.analyze.outputs.has_real_changes }}
+      has_changes: ${{ steps.analyze.outputs.has-real-changes }}
       version: ${{ steps.version.outputs.new_version }}
-      noise_filtered: ${{ steps.analyze.outputs.noise_count }}
+      noise_filtered: ${{ steps.analyze.outputs.noise-count }}
 
     steps:
       - name: Checkout repository
@@ -139,23 +139,23 @@ jobs:
         if: github.event.inputs.skip_noise_filter == 'true'
         run: |
           if git diff --cached --quiet; then
-            echo "has_real_changes=false" >> $GITHUB_OUTPUT
+            echo "has-real-changes=false" >> $GITHUB_OUTPUT
             echo "No changes detected"
           else
-            echo "has_real_changes=true" >> $GITHUB_OUTPUT
+            echo "has-real-changes=true" >> $GITHUB_OUTPUT
             CHANGE_COUNT=$(git diff --cached --name-only | wc -l)
-            echo "real_count=$CHANGE_COUNT" >> $GITHUB_OUTPUT
-            echo "noise_count=0" >> $GITHUB_OUTPUT
-            echo "change_summary=$CHANGE_COUNT changes detected (noise filter disabled)" >> $GITHUB_OUTPUT
+            echo "real-count=$CHANGE_COUNT" >> $GITHUB_OUTPUT
+            echo "noise-count=0" >> $GITHUB_OUTPUT
+            echo "change-summary=$CHANGE_COUNT changes detected (noise filter disabled)" >> $GITHUB_OUTPUT
           fi
 
       - name: Determine if changes exist
         id: has_changes
         run: |
           if [ "${{ github.event.inputs.skip_noise_filter }}" = "true" ]; then
-            echo "result=${{ steps.analyze_raw.outputs.has_real_changes }}" >> $GITHUB_OUTPUT
+            echo "result=${{ steps.analyze_raw.outputs.has-real-changes }}" >> $GITHUB_OUTPUT
           else
-            echo "result=${{ steps.analyze.outputs.has_real_changes }}" >> $GITHUB_OUTPUT
+            echo "result=${{ steps.analyze.outputs.has-real-changes }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Reset staging if no real changes
@@ -218,8 +218,8 @@ jobs:
 
           # Build commit message
           VERSION="${{ steps.version.outputs.new_version }}"
-          REAL_COUNT="${{ steps.analyze.outputs.real_count || steps.analyze_raw.outputs.real_count || '0' }}"
-          NOISE_COUNT="${{ steps.analyze.outputs.noise_count || '0' }}"
+          REAL_COUNT="${{ steps.analyze.outputs.real-count || steps.analyze_raw.outputs.real-count || '0' }}"
+          NOISE_COUNT="${{ steps.analyze.outputs.noise-count || '0' }}"
 
           git commit -m "chore: sync solution from Dev (v${VERSION})
 
@@ -266,12 +266,12 @@ jobs:
             | **Environment** | ${{ vars.POWERPLATFORM_ENVIRONMENT_URL }} |
             | **Solution** | ${{ env.SOLUTION_NAME }} |
             | **Version** | ${{ steps.version.outputs.new_version }} |
-            | **Real Changes** | ${{ steps.analyze.outputs.real_count || steps.analyze_raw.outputs.real_count }} |
-            | **Noise Filtered** | ${{ steps.analyze.outputs.noise_count || '0' }} |
+            | **Real Changes** | ${{ steps.analyze.outputs.real-count || steps.analyze_raw.outputs.real-count }} |
+            | **Noise Filtered** | ${{ steps.analyze.outputs.noise-count || '0' }} |
             | **Run ID** | ${{ github.run_id }} |
 
             ### Change Summary
-            ${{ steps.analyze.outputs.change_summary || steps.analyze_raw.outputs.change_summary }}
+            ${{ steps.analyze.outputs.change-summary || steps.analyze_raw.outputs.change-summary }}
 
             Please review the changes before merging.
           labels: |
@@ -289,8 +289,8 @@ jobs:
 
           if [ "${{ steps.has_changes.outputs.result }}" = "true" ]; then
             echo "| Version | ${{ steps.version.outputs.new_version }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| Real Changes | ${{ steps.analyze.outputs.real_count || steps.analyze_raw.outputs.real_count }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| Noise Filtered | ${{ steps.analyze.outputs.noise_count || '0' }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| Real Changes | ${{ steps.analyze.outputs.real-count || steps.analyze_raw.outputs.real-count }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| Noise Filtered | ${{ steps.analyze.outputs.noise-count || '0' }} |" >> $GITHUB_STEP_SUMMARY
             echo "| Status | **Committed** |" >> $GITHUB_STEP_SUMMARY
 
             if [ "${{ github.event.inputs.create_pr }}" != "true" ]; then


### PR DESCRIPTION
## Summary

Fixes the export workflow incorrectly detecting no changes when real changes existed.

## Root Cause

**GitHub Actions naming convention:**
- Action inputs/outputs use **hyphens** (YAML/kebab-case convention)
- Internal bash variables use **underscores** (shell convention)

The `analyze-changes` composite action correctly defined outputs with hyphens:
```yaml
outputs:
  has-real-changes:    # hyphen (external API)
    value: ${{ steps.analyze.outputs.has_real_changes }}  # underscore (internal)
```

But the workflow was incorrectly referencing with underscores:
```yaml
${{ steps.analyze.outputs.has_real_changes }}  # WRONG - underscore
${{ steps.analyze.outputs.has-real-changes }}  # CORRECT - hyphen
```

## Changes

### ci-export.yml
- Fixed all `steps.analyze.outputs.*` references to use hyphens
- Fixed `analyze_raw` inline step to output with hyphens for consistency
- Fixed all `steps.analyze_raw.outputs.*` references to use hyphens

### _deploy-solution.yml
- Fixed job output `build_succeeded` → `build-succeeded`
- Fixed workflow output reference to match

## Convention Applied

| Context | Convention | Example |
|---------|-----------|---------|
| Action outputs (external) | hyphens | `has-real-changes` |
| Inline step outputs | hyphens | `has-real-changes` |
| Bash variables | underscores | `has_real_changes` |
| Job/workflow output names | hyphens | `build-succeeded` |

## Test plan

- [ ] Run export workflow on this branch
- [ ] Verify real changes are detected and committed