### PR TITLE
fix: default export workflow to PR mode for branch protection

### DIFF
--- a/.github/workflows/ci-export.yml
+++ b/.github/workflows/ci-export.yml
@@ -54,9 +54,9 @@ on:
         required: true
         default: 'PPDSDemo'
       create_pr:
-        description: 'Create PR instead of direct commit'
+        description: 'Create PR instead of direct commit (required for branch protection)'
         required: false
-        default: 'false'
+        default: 'true'
         type: choice
         options:
           - 'true'
@@ -211,7 +211,7 @@ jobs:
           fi
 
       - name: Commit changes to develop
-        if: steps.has_changes.outputs.result == 'true' && github.event.inputs.create_pr != 'true'
+        if: steps.has_changes.outputs.result == 'true' && github.event.inputs.create_pr == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -232,7 +232,7 @@ jobs:
           git push origin develop
 
       - name: Create git tag
-        if: steps.has_changes.outputs.result == 'true' && github.event.inputs.create_pr != 'true'
+        if: steps.has_changes.outputs.result == 'true' && github.event.inputs.create_pr == 'false'
         run: |
           VERSION="${{ steps.version.outputs.new_version }}"
           TAG_NAME="v${VERSION}"
@@ -247,7 +247,7 @@ jobs:
           git push origin "$TAG_NAME"
 
       - name: Create Pull Request
-        if: steps.has_changes.outputs.result == 'true' && github.event.inputs.create_pr == 'true'
+        if: steps.has_changes.outputs.result == 'true' && github.event.inputs.create_pr != 'false'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -293,7 +293,7 @@ jobs:
             echo "| Noise Filtered | ${{ steps.analyze.outputs.noise-count || '0' }} |" >> $GITHUB_STEP_SUMMARY
             echo "| Status | **Committed** |" >> $GITHUB_STEP_SUMMARY
 
-            if [ "${{ github.event.inputs.create_pr }}" != "true" ]; then
+            if [ "${{ github.event.inputs.create_pr }}" == "false" ]; then
               echo "| Git Tag | \`v${{ steps.version.outputs.new_version }}\` |" >> $GITHUB_STEP_SUMMARY
             fi
           else


### PR DESCRIPTION
## Summary
- Change `create_pr` default from `false` to `true`
- Update step conditions to check for explicit `false` value
- Scheduled and manual runs now create PRs by default
- Direct commits only when explicitly requested

## Problem
The CI: Export from Dev workflow was failing because it tried to push directly to `develop`, which violates branch protection rules requiring PRs and status checks.

## Solution
Instead of bypassing branch protection (not available for personal repos), the workflow now creates PRs by default. This:
- Respects branch protection rules
- Creates an audit trail for solution exports
- Allows review before automated changes merge

## Test plan
- [ ] Manually trigger the Export from Dev workflow
- [ ] Verify it creates a PR instead of direct commit
- [ ] Nightly scheduled run should also create PR