### PR TITLE
fix: enable plugin build in deployment workflows

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -76,5 +76,6 @@ jobs:
       environment-name: Prod
       solution-name: ${{ github.event.inputs.solution_name || 'PPDSDemo' }}
       solution-folder: solutions/PPDSDemo/src
+      build-plugins: true
       ref: main
     secrets: inherit

--- a/.github/workflows/cd-qa.yml
+++ b/.github/workflows/cd-qa.yml
@@ -50,5 +50,6 @@ jobs:
       environment-name: QA
       solution-name: ${{ github.event.inputs.solution_name || 'PPDSDemo' }}
       solution-folder: solutions/PPDSDemo/src
+      build-plugins: true
       ref: develop
     secrets: inherit


### PR DESCRIPTION
## Problem

The CD: Deploy to QA workflow is failing with:
```
File not found for file attribute package with file name ppds_PPDSDemo.PluginPackage.nupkg
```

## Root Cause

The solution export from Dev now includes a plugin package reference (`pluginpackage.xml`), but the deployment workflows weren't building the .NET solution to produce the `.nupkg` file.

## Fix

Enable `build-plugins: true` in both `cd-qa.yml` and `cd-prod.yml`.

This ensures the workflow:
1. Builds the .NET solution (including the PluginPackage project)
2. Locates the built `.nupkg` file
3. Copies it to the solution folder before packing
4. Packs and imports the solution with the plugin package included

## Test Plan
- [ ] Merge this PR
- [ ] Verify CD: Deploy to QA succeeds
- [ ] Verify plugin package is included in deployed solution