### PR TITLE
feat: add branch policy enforcement and release tagging

### DIFF
--- a/.github/actions/setup-pac-cli/action.yml
+++ b/.github/actions/setup-pac-cli/action.yml
@@ -7,6 +7,17 @@
 #   - name: Setup PAC CLI
 #     uses: ./.github/actions/setup-pac-cli
 #
+#   # Pin to specific version (recommended for production stability)
+#   - name: Setup PAC CLI
+#     uses: ./.github/actions/setup-pac-cli
+#     with:
+#       pac-version: '1.35.5'
+#
+# Version Pinning:
+#   - Default: empty (installs latest version)
+#   - Set pac-version to pin a specific version for reproducible builds
+#   - Find versions at: https://www.nuget.org/packages/Microsoft.PowerApps.CLI.Tool
+#
 # =============================================================================
 
 name: 'Setup PAC CLI'
@@ -17,6 +28,10 @@ inputs:
     description: '.NET SDK version to install'
     required: false
     default: '8.x'
+  pac-version:
+    description: 'PAC CLI version to install (empty = latest)'
+    required: false
+    default: ''
 
 outputs:
   pac-version:
@@ -34,8 +49,17 @@ runs:
     - name: Install Power Platform CLI
       id: install
       shell: bash
+      env:
+        PAC_VERSION: ${{ inputs.pac-version }}
       run: |
-        dotnet tool install --global Microsoft.PowerApps.CLI.Tool
+        if [ -n "$PAC_VERSION" ]; then
+          echo "Installing PAC CLI version: $PAC_VERSION"
+          dotnet tool install --global Microsoft.PowerApps.CLI.Tool --version "$PAC_VERSION"
+        else
+          echo "Installing latest PAC CLI version"
+          dotnet tool install --global Microsoft.PowerApps.CLI.Tool
+        fi
+
         echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
 
         # Get installed version

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,7 +1,8 @@
 # =============================================================================
 # CD: Deploy to Production
 # =============================================================================
-# Deploys the managed solution to the Production environment.
+# Deploys the managed solution to the Production environment and creates a
+# release tag on successful deployment.
 #
 # Triggers:
 #   - Push to main branch (with solution changes)
@@ -11,6 +12,11 @@
 #   - GitHub Environment protection rules (required reviewers)
 #   - Manual confirmation required for workflow_dispatch
 #   - Only deploys from main branch
+#
+# Release Tagging:
+#   - Creates git tag (vX.X.YYYYMMDD.N) after successful deployment
+#   - Tag version comes from solutions/PPDSDemo/version.txt
+#   - Tags are only created on push events (not manual dispatches)
 #
 # =============================================================================
 # GITHUB ENVIRONMENT REQUIRED
@@ -79,3 +85,96 @@ jobs:
       build-plugins: true
       ref: main
     secrets: inherit
+
+  # ===========================================================================
+  # Create Release Tag - After successful deployment
+  # ===========================================================================
+  create-release-tag:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    needs: [deploy-to-prod]
+    if: github.event_name == 'push' && needs.deploy-to-prod.outputs.deployed == 'true'
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION_FILE="solutions/PPDSDemo/version.txt"
+
+          if [ -f "$VERSION_FILE" ]; then
+            VERSION=$(cat "$VERSION_FILE" | tr -d '[:space:]')
+            echo "Version from file: $VERSION"
+          else
+            # Fallback: extract from Solution.xml
+            SOLUTION_XML="solutions/PPDSDemo/src/Other/Solution.xml"
+            VERSION=$(grep -oP '(?<=<Version>)[^<]+' "$SOLUTION_XML" | head -1 || echo "")
+            echo "Version from Solution.xml: $VERSION"
+          fi
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not determine version"
+            exit 1
+          fi
+
+          TAG_NAME="v${VERSION}"
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: check-tag
+        run: |
+          TAG_NAME="${{ steps.version.outputs.tag_name }}"
+
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Tag $TAG_NAME already exists, skipping"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag $TAG_NAME does not exist, will create"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create and push tag
+        if: steps.check-tag.outputs.exists == 'false'
+        run: |
+          TAG_NAME="${{ steps.version.outputs.tag_name }}"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$TAG_NAME" -m "Release $VERSION
+
+          Deployed to Production via CD pipeline.
+
+          Commit: ${{ github.sha }}
+          Workflow: ${{ github.run_id }}"
+
+          git push origin "$TAG_NAME"
+
+          echo "Created and pushed tag: $TAG_NAME"
+
+      - name: Tag summary
+        run: |
+          echo "## Release Tag" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ steps.check-tag.outputs.exists }}" = "true" ]; then
+            echo "Tag \`${{ steps.version.outputs.tag_name }}\` already exists - skipped creation" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Created tag: \`${{ steps.version.outputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Version | ${{ steps.version.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Commit | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-export.yml
+++ b/.github/workflows/ci-export.yml
@@ -22,7 +22,8 @@
 #   6. Commit changes to develop branch (or create PR)
 #
 # The commit to develop will trigger cd-qa.yml for automatic QA deployment.
-# Tags are created on main branch merges (releases), not on exports.
+# Release tags are created automatically by cd-prod.yml after successful
+# production deployments (not during exports).
 #
 # =============================================================================
 # GITHUB ENVIRONMENT REQUIRED

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -17,6 +17,11 @@
 #
 # This catches code, structural, and quality issues before they reach QA/Production.
 #
+# Branch Policy Enforcement:
+#   - PRs to main: Only allowed from 'develop' or 'hotfix/*' branches
+#   - PRs to develop: Allowed from any branch
+#   - See docs/strategy/BRANCHING_STRATEGY.md for details
+#
 # =============================================================================
 
 name: 'PR: Validate Solution'
@@ -88,11 +93,53 @@ env:
 
 jobs:
   # ============================================
-  # Job 0: Dependency Review (Security)
+  # Job 0: Branch Policy Enforcement
+  # ============================================
+  branch-policy:
+    name: Branch Policy
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Validate PR branch policy
+        if: github.base_ref == 'main'
+        run: |
+          SOURCE="${{ github.head_ref }}"
+          echo "PR source branch: $SOURCE"
+          echo "PR target branch: ${{ github.base_ref }}"
+
+          if [[ "$SOURCE" == "develop" || "$SOURCE" =~ ^hotfix/ ]]; then
+            echo "✓ Branch '$SOURCE' is allowed to target main"
+          else
+            echo ""
+            echo "::error::PRs to main must come from 'develop' or 'hotfix/*' branches"
+            echo "::error::Source branch '$SOURCE' is not allowed to target main."
+            echo "::error::Please target 'develop' instead, or rename to 'hotfix/*' for emergency fixes."
+            echo ""
+            echo "Branch Policy:"
+            echo "  - feature/* and fix/* branches → must target 'develop'"
+            echo "  - hotfix/* branches → can target 'main' (emergency fixes)"
+            echo "  - develop → merges to 'main' (releases)"
+            echo ""
+            echo "See docs/strategy/BRANCHING_STRATEGY.md for details."
+            exit 1
+          fi
+
+      - name: Branch policy passed
+        run: |
+          if [ "${{ github.base_ref }}" = "main" ]; then
+            echo "✓ Branch policy check passed for PR to main"
+          else
+            echo "✓ No branch restriction for PRs to ${{ github.base_ref }}"
+          fi
+
+  # ============================================
+  # Job 1: Dependency Review (Security)
   # ============================================
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    needs: [branch-policy]
     if: github.event_name == 'pull_request'
 
     steps:
@@ -108,7 +155,7 @@ jobs:
           deny-licenses: GPL-3.0, AGPL-3.0
 
   # ============================================
-  # Job 1: Build and Test .NET Code
+  # Job 2: Build and Test .NET Code
   # ============================================
   build-code:
     name: Build & Test Code
@@ -152,7 +199,7 @@ jobs:
           echo "::notice::No .NET solution found - skipping code build"
 
   # ============================================
-  # Job 2: Validate Solution Structure
+  # Job 3: Validate Solution Structure
   # ============================================
   validate-solution:
     name: Validate Solution
@@ -374,24 +421,31 @@ jobs:
         run: rm -rf ${{ env.SOLUTION_EXPORT_FOLDER }}
 
   # ============================================
-  # Job 3: Final Status Check
+  # Job 4: Final Status Check
   # ============================================
   status-check:
     name: Validation Status
     runs-on: ubuntu-latest
-    needs: [dependency-review, build-code, validate-solution]
+    needs: [branch-policy, dependency-review, build-code, validate-solution]
     if: always()
 
     steps:
       - name: Check overall status
         run: |
+          BRANCH_POLICY_RESULT="${{ needs.branch-policy.result }}"
           DEPENDENCY_RESULT="${{ needs.dependency-review.result }}"
           BUILD_RESULT="${{ needs.build-code.result }}"
           VALIDATE_RESULT="${{ needs.validate-solution.result }}"
 
+          echo "Branch policy result: $BRANCH_POLICY_RESULT"
           echo "Dependency review result: $DEPENDENCY_RESULT"
           echo "Build job result: $BUILD_RESULT"
           echo "Validate job result: $VALIDATE_RESULT"
+
+          if [ "$BRANCH_POLICY_RESULT" = "failure" ]; then
+            echo "::error::Branch policy check failed - PR source branch not allowed to target this branch"
+            exit 1
+          fi
 
           if [ "$DEPENDENCY_RESULT" = "failure" ]; then
             echo "::error::Dependency review failed - vulnerable or unlicensed dependencies detected"

--- a/docs/strategy/BRANCHING_STRATEGY.md
+++ b/docs/strategy/BRANCHING_STRATEGY.md
@@ -13,7 +13,36 @@ We use a simplified GitFlow model with two primary branches.
 | `main` | Production-ready code | Yes | Prod |
 | `develop` | Integration branch | Yes | QA |
 | `feature/*` | Feature development | No | - |
+| `fix/*` | Bug fixes (normal priority) | No | - |
 | `hotfix/*` | Emergency fixes | No | - |
+
+---
+
+## Branch Policy Enforcement
+
+PRs to `main` are restricted to ensure release integrity. This is enforced automatically by the PR validation workflow.
+
+| Source Branch | Allowed Target | Use Case |
+|---------------|----------------|----------|
+| `feature/*` | `develop` only | New functionality |
+| `fix/*` | `develop` only | Bug fixes (normal priority) |
+| `hotfix/*` | `main` | Emergency production fixes (then cherry-pick to develop) |
+| `develop` | `main` | Release merges |
+
+**Automated Enforcement:**
+
+The `pr-validate.yml` workflow checks branch policy on every PR:
+- PRs to `main` from unauthorized branches (e.g., `feature/*`, `fix/*`) will **fail** with a clear error message
+- PRs to `develop` are allowed from any branch
+- Ensures only tested code reaches production via the proper flow
+
+If you attempt to create a PR from `feature/my-change` to `main`, you'll see:
+
+```
+::error::PRs to main must come from 'develop' or 'hotfix/*' branches
+::error::Source branch 'feature/my-change' is not allowed to target main.
+::error::Please target 'develop' instead, or rename to 'hotfix/*' for emergency fixes.
+```
 
 ---
 
@@ -74,24 +103,27 @@ graph LR
 
 ---
 
-### `feature/*` Branches
+### `feature/*` and `fix/*` Branches
 
-**Purpose:** Isolated development of specific features or changes.
+**Purpose:** Isolated development of specific features or bug fixes.
 
-**Naming:** `feature/{short-description}`
+**Naming:**
+- `feature/{short-description}` - New functionality
+- `fix/{short-description}` - Bug fixes (normal priority)
 
 **Examples:**
 ```
 feature/add-account-validation
 feature/new-contact-form
-feature/update-business-rules
+fix/workflow-error-handling
+fix/form-validation-bug
 ```
 
 **Workflow:**
 1. Create from `develop`
 2. Make changes in Dev environment
-3. Export and commit to feature branch
-4. Create PR to `develop`
+3. Export and commit to feature/fix branch
+4. Create PR to `develop` (PRs to `main` will be rejected)
 5. Delete after merge
 
 ---


### PR DESCRIPTION
## Summary
Adds automated branch policy enforcement to ensure proper release flow.

## Changes
- **pr-validate.yml**: Add branch policy job that rejects PRs to \main\ unless from \develop\ or \hotfix/*\
- **cd-prod.yml**: Add automatic release tagging after successful production deployments
- **ci-export.yml**: Update comments about release tag timing
- **BRANCHING_STRATEGY.md**: Document \ix/*\ branch type and policy enforcement

## Why
Prevents accidental direct PRs to main from feature branches, ensuring all changes flow through develop and QA first.