### PR TITLE
fix: download CD Prod artifacts from develop branch

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -112,7 +112,7 @@ jobs:
             echo "Using artifact from specified run: $RUN_ID"
             echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
           else
-            echo "Will find latest CI Build artifact from main branch"
+            echo "Will find latest CI Build artifact from develop branch"
             echo "run-id=" >> $GITHUB_OUTPUT
           fi
 
@@ -125,12 +125,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ steps.source.outputs.run-id }}
 
-      - name: Download latest artifact (from main)
+      - name: Download latest artifact (from develop)
         if: steps.source.outputs.run-id == ''
         uses: dawidd6/action-download-artifact@v11
         with:
           workflow: ci-build.yml
-          branch: main
+          branch: develop
           name_is_regexp: true
           name: ${{ steps.source.outputs.solution-name }}-.*
           path: ./artifact


### PR DESCRIPTION
## Summary
- Fixes CD Prod workflow failing to find artifacts

## Problem
CI Build only runs on `develop` branch, but CD Prod was trying to download artifacts from `main` branch - which don't exist.

## Solution
Changed artifact download to use `develop` branch, ensuring CD Prod gets the same artifact that was already deployed to QA.

## Changes
- Updated `cd-prod.yml` to download artifacts from `develop` instead of `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)