### PR TITLE
fix: remove Windows-specific path from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 **Reference implementation for Dynamics 365 / Dataverse projects.**
 
-**Part of the PPDS Ecosystem** - See `C:\VS\ppds\CLAUDE.md` for cross-project context.
+**Part of the PPDS Ecosystem** - See `../CLAUDE.md` for cross-project context.
 
 ---
 


### PR DESCRIPTION
## Summary
Replace hardcoded `C:\VS\ppds\CLAUDE.md` path with cross-platform reference.

## Changes
- Before: `See C:\VS\ppds\CLAUDE.md for cross-project context`
- After: `See parent workspace CLAUDE.md for cross-project context`

Addresses feedback from gemini-code-assist about cross-platform clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)