### PR TITLE
deps: consolidated February 2026 dependency updates

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Download latest artifact (from develop)
         if: steps.source.outputs.run-id == ''
-        uses: dawidd6/action-download-artifact@v12
+        uses: dawidd6/action-download-artifact@v15
         with:
           workflow: ci-build.yml
           branch: develop

--- a/.github/workflows/cd-qa.yml
+++ b/.github/workflows/cd-qa.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Download latest artifact (manual trigger)
         if: steps.source.outputs.run-id == ''
-        uses: dawidd6/action-download-artifact@v12
+        uses: dawidd6/action-download-artifact@v15
         with:
           workflow: ci-build.yml
           branch: develop

--- a/src/Console/PPDS.Dataverse.Demo/PPDS.Dataverse.Demo.csproj
+++ b/src/Console/PPDS.Dataverse.Demo/PPDS.Dataverse.Demo.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.1" />
     <PackageReference Include="CsvHelper" Version="33.*" />
     <PackageReference Include="PPDS.Dataverse" Version="1.0.0-beta.4" />

--- a/src/Functions/PPDSDemo.Functions/PPDSDemo.Functions.csproj
+++ b/src/Functions/PPDSDemo.Functions/PPDSDemo.Functions.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <!-- Microsoft.Extensions.Http 8.x is latest for net8.0; 10.x requires net10 -->
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Consolidates 3 dependabot PRs into a single update:

| Package | From | To | Type |
|---------|------|----|------|
| Microsoft.Extensions.Hosting | 10.0.1 | 10.0.3 | Patch |
| Microsoft.Extensions.Configuration.Json | 10.0.1 | 10.0.3 | Patch |
| Microsoft.Extensions.Http | 10.0.1 | 10.0.3 | Patch |
| dawidd6/action-download-artifact | v12 | v15 | Major (GH Action) |

### Excluded (deferred for separate review)
- **Microsoft.PowerApps.MSBuild.Plugin 1.52.1 → 2.2.1** (#99) — Major version, needs plugin deployment verification
- **Microsoft.ApplicationInsights.WorkerService 2.23.0 → 3.0.0** (#94) — CI failing, breaking changes
- **PPDS.Dataverse + PPDS.Migration** (#90) — CI failing, breaking changes in beta packages

### Source PRs
Closes #95, closes #97, closes #98

## Test plan
- [x] `dotnet restore` succeeds
- [x] `dotnet build` succeeds (no new warnings)
- [ ] CI pipeline passes (Build & Test, CodeQL, Validate Solution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)